### PR TITLE
feat: release bumper helper script

### DIFF
--- a/core-linux/src/settings.cpp
+++ b/core-linux/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Linux';";
-        s += "var NL_VERSION='1.1.0';";
+        s += "var NL_VERSION='1.2.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-linux/src/settings.cpp
+++ b/core-linux/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Linux';";
-        s += "var NL_VERSION='1.0.8';";
+        s += "var NL_VERSION='1.1.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-linux/src/settings.cpp
+++ b/core-linux/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Linux';";
-        s += "var NL_VERSION='1.2.0';";
+        s += "var NL_VERSION='1.3.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-macos/src/settings.cpp
+++ b/core-macos/src/settings.cpp
@@ -94,7 +94,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='MacOS(Darwin)';";
-        s += "var NL_VERSION='1.0.8';";
+        s += "var NL_VERSION='1.1.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-macos/src/settings.cpp
+++ b/core-macos/src/settings.cpp
@@ -94,7 +94,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='MacOS(Darwin)';";
-        s += "var NL_VERSION='1.2.0';";
+        s += "var NL_VERSION='1.3.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-macos/src/settings.cpp
+++ b/core-macos/src/settings.cpp
@@ -94,7 +94,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='MacOS(Darwin)';";
-        s += "var NL_VERSION='1.1.0';";
+        s += "var NL_VERSION='1.2.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-windows/bin/version_info
+++ b/core-windows/bin/version_info
@@ -15,8 +15,8 @@ BLOCK "StringFileInfo"
 		VALUE "CompanyName", "Neutralino Team"
 		VALUE "LegalCopyright", "\xA9 Neutralino"
 		VALUE "ProductName", "Neutralinojs Framework"
-		VALUE "FileVersion", "1.2.0"
-		VALUE "ProductVersion", "1.2.0"
+		VALUE "FileVersion", "1.3.0"
+		VALUE "ProductVersion", "1.3.0"
 	}
 }
 

--- a/core-windows/bin/version_info
+++ b/core-windows/bin/version_info
@@ -15,8 +15,8 @@ BLOCK "StringFileInfo"
 		VALUE "CompanyName", "Neutralino Team"
 		VALUE "LegalCopyright", "\xA9 Neutralino"
 		VALUE "ProductName", "Neutralinojs Framework"
-		VALUE "FileVersion", "1.1.0"
-		VALUE "ProductVersion", "1.1.0"
+		VALUE "FileVersion", "1.2.0"
+		VALUE "ProductVersion", "1.2.0"
 	}
 }
 

--- a/core-windows/bin/version_info
+++ b/core-windows/bin/version_info
@@ -15,8 +15,8 @@ BLOCK "StringFileInfo"
 		VALUE "CompanyName", "Neutralino Team"
 		VALUE "LegalCopyright", "\xA9 Neutralino"
 		VALUE "ProductName", "Neutralinojs Framework"
-		VALUE "FileVersion", "1.0.8"
-		VALUE "ProductVersion", "1.0.8"
+		VALUE "FileVersion", "1.1.0"
+		VALUE "ProductVersion", "1.1.0"
 	}
 }
 

--- a/core-windows/src/settings.cpp
+++ b/core-windows/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Windows';";
-        s += "var NL_VERSION='1.2.0';";
+        s += "var NL_VERSION='1.3.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-windows/src/settings.cpp
+++ b/core-windows/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Windows';";
-        s += "var NL_VERSION='1.1.0';";
+        s += "var NL_VERSION='1.2.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/core-windows/src/settings.cpp
+++ b/core-windows/src/settings.cpp
@@ -68,7 +68,7 @@ namespace settings {
     string getGlobalVars(){
         json settings = getOptions();
         string s = "var NL_OS='Windows';";
-        s += "var NL_VERSION='1.0.8';";
+        s += "var NL_VERSION='1.1.0';";
         s += "var NL_NAME='" + settings["appname"].get<std::string>() + "';"; 
         s += "var NL_PORT=" + settings["appport"].get<std::string>() + ";";
         s += "var NL_MODE='" + settings["mode"].get<std::string>() + "';";

--- a/neutralino.js/package-lock.json
+++ b/neutralino.js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/neutralino.js/package-lock.json
+++ b/neutralino.js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/neutralino.js/package-lock.json
+++ b/neutralino.js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/neutralino.js/package-lock.json
+++ b/neutralino.js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/neutralino.js/package.json
+++ b/neutralino.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/neutralino.js/package.json
+++ b/neutralino.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/neutralino.js/package.json
+++ b/neutralino.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/neutralino.js/package.json
+++ b/neutralino.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutralino-client-library",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/version-bump.js
+++ b/version-bump.js
@@ -1,0 +1,122 @@
+const { promisify } = require("util");
+const { exec } = require("child_process");
+const execPromise = promisify(exec);
+const fs = require("fs");
+
+let newVersion = "";
+const BUMP_TYPES = {
+  Major: "major",
+  Minor: "minor",
+  Patch: "patch"
+};
+
+(async () => {
+  if (process.argv.length < 3) {
+    console.error("ERROR: Please enter a [major/minor/patch] version bump.");
+    process.exit(1);
+  }
+
+  const bump = process.argv[2].toLowerCase();
+
+  if (
+    bump !== BUMP_TYPES.Major &&
+    bump !== BUMP_TYPES.Minor &&
+    bump !== BUMP_TYPES.Patch
+  ) {
+    console.error("ERROR: Please enter a [major/minor/patch] version bump.");
+    process.exit(1);
+  }
+
+  // use native npm version CLI command for npm version bump
+  const { stdout } = await execPromise(`npm version ${bump}`, {
+    cwd: "./neutralino.js"
+  });
+
+  const newVersion = stdout.slice(1).trim();
+
+  // manually bump version number for CPP files
+  const cppFilePaths = [
+    "./core-linux/src/settings.cpp",
+    "./core-macos/src/settings.cpp",
+    "./core-windows/src/settings.cpp",
+    "./core-windows/bin/version_info"
+  ];
+
+  cppFilePaths.forEach(filePath => {
+    let contents = fs.readFileSync(filePath, { encoding: "utf-8" });
+
+    if (filePath.includes("settings.cpp")) {
+      const oldVersion = contents.match(
+        /NL_VERSION='([0-9+]+\.[0-9+]+\.[0-9]+)'/
+      )[1];
+      const newV = bumpVersion(oldVersion, bump);
+
+      if (newV !== newVersion) {
+        console.log(newVersion.length);
+        console.error(
+          `Package versions in files do not match (${newV} and ${newVersion})`
+        );
+        process.exit(1);
+      }
+
+      contents = contents.replace(
+        `NL_VERSION='${oldVersion}'`,
+        `NL_VERSION='${newVersion}'`
+      );
+    } else {
+      const oldFileVersion = contents.match(
+        /"FileVersion", "([0-9+]+\.[0-9+]+\.[0-9]+)"/
+      )[1];
+      const oldProductVersion = contents.match(
+        /"ProductVersion", "([0-9+]+\.[0-9+]+\.[0-9]+)"/
+      )[1];
+
+      const newFileVersion = bumpVersion(oldFileVersion, bump);
+      const newProductVersion = bumpVersion(oldProductVersion, bump);
+
+      if (newFileVersion !== newVersion || newProductVersion !== newVersion) {
+        console.error(
+          `Package versions in files do not match (${newFileVersion}/${newProductVersion} and ${newVersion})`
+        );
+        process.exit(1);
+      }
+
+      contents = contents
+        .replace(
+          `"FileVersion", "${oldFileVersion}"`,
+          `"FileVersion", "${newVersion}"`
+        )
+        .replace(
+          `"ProductVersion", "${oldProductVersion}"`,
+          `"ProductVersion", "${newVersion}"`
+        );
+    }
+
+    fs.writeFileSync(filePath, contents);
+  });
+
+  // commit and tag
+  await execPromise(
+    `git add --all && git commit -m "v${newVersion}" && git tag v${newVersion}`
+  );
+})();
+
+function bumpVersion(oldVersion, bumpType) {
+  if (typeof oldVersion !== "string" || typeof bumpType !== "string") {
+    return;
+  }
+  let [majorV, minorV, patchV] = oldVersion.split(".");
+
+  if (bumpType === BUMP_TYPES.Major) {
+    majorV++;
+    minorV = 0;
+    patchV = 0;
+  } else if (bumpType === BUMP_TYPES.Minor) {
+    minorV++;
+    patchV = 0;
+  } else if (bumpType === BUMP_TYPES.Patch) {
+    patchV++;
+  }
+
+  return `${majorV}.${minorV}.${patchV}`;
+}

--- a/version-bump.js
+++ b/version-bump.js
@@ -3,7 +3,6 @@ const { exec } = require("child_process");
 const execPromise = promisify(exec);
 const fs = require("fs");
 
-let newVersion = "";
 const BUMP_TYPES = {
   Major: "major",
   Minor: "minor",
@@ -52,7 +51,6 @@ const BUMP_TYPES = {
       const newV = bumpVersion(oldVersion, bump);
 
       if (newV !== newVersion) {
-        console.log(newVersion.length);
         console.error(
           `Package versions in files do not match (${newV} and ${newVersion})`
         );


### PR DESCRIPTION
## Description
Zero-dependency Node.js script that bumps the version number of the NeutralinoJS content at the JS and C++ levels.

Then, commits and tags the release number.

## How to test it
`node ./version-bump.js [major/minor/patch]`
## Next steps

This is to be used in conjunction with a GitHub Action that zips everything up and adds binaries as release assets, in order to close #5 and #6.

## Deploy notes
<!--
    Notes about how to deploy the feature/enhancement you are deploying.
-->

None.